### PR TITLE
Set correct content type and filename for mixed multipart uploads

### DIFF
--- a/lib/immoscout/models/actions/attachment.rb
+++ b/lib/immoscout/models/actions/attachment.rb
@@ -23,7 +23,11 @@ module Immoscout
               "user/#{api.user_name}/realestate/#{attachable_id}/attachment",
               nil,
               attachment: Faraday::UploadIO.new(file, content_type, file_name),
-              metadata: as_json
+              metadata: Faraday::UploadIO.new(
+                StringIO.new(to_json),
+                'application/json',
+                'metadata.json'
+              )
             )
             handle_response(response)
             self.id = id_from_response(response)


### PR DESCRIPTION
The immobilienscout24 API needs for the second multipart part (which includes the metadata) also content-type and filename. This PR sets for the metadata part to `application/json` with filename `metadata.json`. Without this change, no metadata information for picture and document uploads are applied. 